### PR TITLE
Updated README wording to reflect https://alexvasilkov.com/gradle-git

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ git {
 
 **Note that the plugin only works with Groovy scripts, no Kotlin DSL support is available yet.**
 
-Now in project's `build.gradle` add the following:
+Now in module's `build.gradle` add the following:
 
 ```
 git {


### PR DESCRIPTION
Maybe I'm wrong, but I've always understood the "Project level" build.gradle file to be the parent-most, while the "module level" build.gradle file being specific to some app. This difference in wording caused me to debug for a good 10-15 min, so figured I'd save others the hassle. Feel free to update or require changes to this PR, but just wanted to call attention to the discrepancy. 